### PR TITLE
Improve README and NTP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-Sparky NTP Server
-This privides ntp own config for Sparky Server.
+# Sparky NTP Server
+
+This package provides its own NTP configuration for Sparky Server.
+It synchronizes the system clock with the official Brazilian time
+servers maintained by the government (ntp.br).
+
+The provided `etc/sparky-ntp.conf` is copied to `/etc/sparky-ntp.conf`
+by the installation script. You can further customize this file to add
+additional peers or adjust restrictions as needed.
 
 Copyright (C) 2019-2020 Daniel Campos Ramos & Paweł Pijanowski
 
@@ -16,16 +23,22 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-Dependencies:
--------------
-ntp
+## Dependencies
 
-Install:
--------------
-su (or sudo) 
+* `ntp` package
+
+## Install
+
+Run as root (or with `sudo`):
+
+```
 ./install.sh
+```
 
-Uninstall:
--------------
-su (or sudo)
+## Uninstall
+
+Run as root (or with `sudo`):
+
+```
 ./install.sh uninstall
+```

--- a/etc/sparky-ntp.conf
+++ b/etc/sparky-ntp.conf
@@ -1,15 +1,18 @@
-# Local Watch address ( Note: this is not the localhost address !)
+# Local clock address (Note: this is not the localhost address!)
 server 127.127.1.0
 fudge  127.127.1.0 stratum 10
 
-# Time source , where to get time from.
-server 0.pool.ntp.org     iburst prefer
+# Time source, where to get time from. Use the official
+# Brazilian government NTP servers provided by ntp.br.
+server a.st1.ntp.br    iburst prefer
+server b.st1.ntp.br    iburst
+server c.st1.ntp.br    iburst
 
 driftfile       /var/lib/ntp/ntp.drift
 logfile         /var/log/ntp
 ntpsigndsocket  /usr/local/samba/var/lib/ntp_signd/
 
-# Acess control
+# Access control
 # Restriction
 # Default: Only answer if consulted from (incl ms-SNTP).
 restrict default kod nomodify notrap nopeer mssntp
@@ -18,6 +21,6 @@ restrict default kod nomodify notrap nopeer mssntp
 restrict 127.0.0.1
 
 # Restrict to strictly serve time, nothing else
-restrict 0.pool.ntp.org   mask 255.255.255.255    nomodify notrap nopeer noquery
-restrict 1.pool.ntp.org   mask 255.255.255.255    nomodify notrap nopeer noquery
-restrict 2.pool.ntp.org   mask 255.255.255.255    nomodify notrap nopeer noquery
+restrict a.st1.ntp.br     mask 255.255.255.255    nomodify notrap nopeer noquery
+restrict b.st1.ntp.br     mask 255.255.255.255    nomodify notrap nopeer noquery
+restrict c.st1.ntp.br     mask 255.255.255.255    nomodify notrap nopeer noquery


### PR DESCRIPTION
## Summary
- clean up README format and wording
- add mention of Brazil time servers
- fix typos in sparky-ntp.conf and point to ntp.br servers

## Testing
- `sh -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f4ae3d15483249d87f961f2b75bc0